### PR TITLE
change TLSv1.2 protocol

### DIFF
--- a/lib/find-emails.js
+++ b/lib/find-emails.js
@@ -113,7 +113,10 @@ module.exports = function findEmails (args, callback) {
 
   if (args.ssl) {
     imapOptions.tlsOptions = {
-      secureProtocol: 'TLSv1_method'
+      //secureProtocol: 'TLSv1_method'
+      rejectUnauthorized: false, 
+      secureProtocol: 'TLSv1_2_method',
+      
     }
   }
 


### PR DESCRIPTION
A TLS/SSL connection established with these methods will only understand the TLSv1.2 protocol.